### PR TITLE
HTTP Improvements

### DIFF
--- a/openphoto/errors.py
+++ b/openphoto/errors.py
@@ -6,6 +6,10 @@ class OpenPhotoDuplicateError(OpenPhotoError):
     """ Indicates that an upload operation failed due to a duplicate photo """
     pass
 
+class OpenPhoto404Error(Exception):
+    """ Indicates that an Http 404 error code was received (resource not found) """
+    pass
+
 class NotImplementedError(OpenPhotoError):
     """ Indicates that the API function has not yet been coded - please help! """
     pass

--- a/openphoto/openphoto_http.py
+++ b/openphoto/openphoto_http.py
@@ -1,7 +1,6 @@
 import oauth2 as oauth
 import urlparse
 import urllib
-import urllib2
 import httplib2
 import logging
 try:
@@ -90,11 +89,11 @@ class OpenPhotoHttp:
             # Parameters must be signed and encoded into the multipart body
             params = self._sign_params(client, url, params)
             headers, body = encode_multipart_formdata(params, files)
-            request = urllib2.Request(url, body, headers)
-            content = urllib2.urlopen(request).read()
         else:
             body = urllib.urlencode(params)
-            _, content = client.request(url, "POST", body)
+            headers = None
+
+        _, content = client.request(url, "POST", body, headers)
 
         # TODO: Don't log file data in multipart forms
         self._logger.info("============================")

--- a/openphoto/openphoto_http.py
+++ b/openphoto/openphoto_http.py
@@ -87,19 +87,19 @@ class OpenPhotoHttp:
 
         if files:
             # Parameters must be signed and encoded into the multipart body
-            params = self._sign_params(client, url, params)
-            headers, body = encode_multipart_formdata(params, files)
+            signed_params = self._sign_params(client, url, params)
+            headers, body = encode_multipart_formdata(signed_params, files)
         else:
             body = urllib.urlencode(params)
             headers = None
 
         _, content = client.request(url, "POST", body, headers)
 
-        # TODO: Don't log file data in multipart forms
         self._logger.info("============================")
         self._logger.info("POST %s" % url)
-        if body:
-            self._logger.info(body)
+        self._logger.info("params: %s" % repr(params))
+        if files:
+            self._logger.info("files:  %s" % repr(files))
         self._logger.info("---")
         self._logger.info(content)
 

--- a/tests/test_photos.py
+++ b/tests/test_photos.py
@@ -23,9 +23,11 @@ class TestPhotos(test_base.TestBase):
         self.client.photo.upload_encoded("tests/test_photo3.jpg",
                                          title=self.TEST_TITLE)
 
-        # Check there are now three photos
+        # Check there are now three photos with the correct titles
         self.photos = self.client.photos.list()
         self.assertEqual(len(self.photos), 3)
+        for photo in self.photos:
+            self.assertEqual(photo.title, self.TEST_TITLE)
 
         # Check that the upload return value was correct
         pathOriginals = [photo.pathOriginal for photo in self.photos]


### PR DESCRIPTION
1) There's no need to use urllib2 for multipart post - use the OAuth2 Client, to be more consistent with the other GET/POST methods.

2) Improve HTTP logging. In particular, don't clutter the logfile with multipart file contents.

3) If the OpenPhoto JSON response can't be decoded, use the HTTP response code instead. This gives a much more sane error message in the case of a 404.
