### PR TITLE
Allow config files to be used everywhere

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -46,7 +46,7 @@ The OpenPhoto Python class hierarchy mirrors the [OpenPhoto API](http://theopenp
 <a name="cli"></a>
 ### Using from the command line
 
-When using the command line tool, you'll want to export your authentication credentials to the environment. 
+When using the command line tool, you'll want to export your authentication credentials to the environment.
 The command line tool will look for the following config file in ~/.config/openphoto/default
 (the -c switch lets you specify a different config file):
 
@@ -63,7 +63,7 @@ These are the options you can pass to the shell program:
 
     -h             # Display help text
     -c config_file # Either the name of a config file in ~/.config/openphoto/ or a full path to a config file
-    -H hostname    # Overrides config_file for unauthenticated API calls [default=localhost]
+    -H hostname    # Overrides config_file for unauthenticated API calls
     -e endpoint    # [default=/photos/list.json]
     -X method      # [default=GET]
     -F params      # e.g. -F 'title=my title' -F 'tags=mytag1,mytag2'
@@ -113,5 +113,8 @@ You can run commands to the OpenPhoto API from your shell!
 <a name="credentials"></a>
 #### Getting your credentials
 
-You can get your credentals by clicking on the arrow next to your email address once you're logged into your site and then clicking on settings.
-If you don't have any credentials then you can create one for yourself using the "Create a new app" button.
+To get your credentials:
+ * Log into your Trovebox site
+ * Click the arrow on the top-right and select 'Settings'.
+ * Click the 'Create a new app' button.
+ * Click the 'View' link beside the newly created app.

--- a/README.markdown
+++ b/README.markdown
@@ -8,47 +8,10 @@ Open Photo API / Python Library
     python setup.py install
 
 ----------------------------------------
+<a name="credentials"></a>
+### Credentials
 
-<a name="python"></a>
-### How to use the library
-
-To use the library you need to first ``import openphoto`` then instantiate an instance of the class and start making calls.
-
-You can use the library in one of two ways:
-
- * Direct GET/POST calls to the server
- * Access via Python classes/methods
-
-<a name="get_post"></a>
-### Direct GET/POST:
-
-    from openphoto import OpenPhoto
-    client = OpenPhoto(host, consumerKey, consumerSecret, token, tokenSecret)
-    resp = client.get("/photos/list.json")
-    resp = client.post("/photo/62/update.json", tags=["tag1", "tag2"])
-
-<a name="python_classes"></a>
-### Python classes/methods
-
-    from openphoto import OpenPhoto
-    client = OpenPhoto(host, consumerKey, consumerSecret, token, tokenSecret)
-    photos = client.photos.list()
-    photos[0].update(tags=["tag1", "tag2"])
-    print photos[0].tags
-
-The OpenPhoto Python class hierarchy mirrors the [OpenPhoto API](http://theopenphotoproject.org/documentation) endpoint layout. For example, the calls in the example above use the following API endpoints:
-
-* client.photos.list() -> /photos/list.json
-* photos[0].update() -> /photo/&lt;id&gt;/update.json
-
-----------------------------------------
-
-<a name="cli"></a>
-### Using from the command line
-
-When using the command line tool, you'll want to export your authentication credentials to the environment.
-The command line tool will look for the following config file in ~/.config/openphoto/default
-(the -c switch lets you specify a different config file):
+For full access to your photos, you need to create the following config file in ``~/.config/openphoto/default``
 
     # ~/.config/openphoto/default
     host = your.host.com
@@ -57,7 +20,51 @@ The command line tool will look for the following config file in ~/.config/openp
     token = your_access_token
     tokenSecret = your_access_token_secret
 
-<a href="#credentials">Click here for instructions on getting credentials</a>.
+The ``config_file`` switch lets you specify a different config file.
+
+To get your credentials:
+ * Log into your Trovebox site
+ * Click the arrow on the top-right and select 'Settings'
+ * Click the 'Create a new app' button
+ * Click the 'View' link beside the newly created app
+
+----------------------------------------
+<a name="python"></a>
+### How to use the library
+
+You can use the library in one of two ways:
+
+ * Direct GET/POST calls to the server
+ * Access via Python classes/methods
+
+<a name="get_post"></a>
+#### Direct GET/POST:
+
+    from openphoto import OpenPhoto
+    client = OpenPhoto()
+    resp = client.get("/photos/list.json")
+    resp = client.post("/photo/62/update.json", tags=["tag1", "tag2"])
+
+<a name="python_classes"></a>
+#### Python classes/methods
+
+    from openphoto import OpenPhoto
+    client = OpenPhoto()
+    photos = client.photos.list()
+    photos[0].update(tags=["tag1", "tag2"])
+    print photos[0].tags
+
+The OpenPhoto Python class hierarchy mirrors the [OpenPhoto API](http://theopenphotoproject.org/documentation) endpoint layout. For example, the calls in the example above use the following API endpoints:
+
+* ``client.photos.list() -> /photos/list.json``
+* ``photos[0].update()   -> /photo/<id>/update.json``
+
+----------------------------------------
+
+<a name="cli"></a>
+### Using from the command line
+
+You can run commands to the OpenPhoto API from your shell!
 
 These are the options you can pass to the shell program:
 
@@ -70,7 +77,8 @@ These are the options you can pass to the shell program:
     -p             # Pretty print the json
     -v             # Verbose output
 
-You can run commands to the OpenPhoto API from your shell!
+<a name="cli-examples"></a>
+#### Command line examples
 
     # Upload a public photo to the host specified in ~/.config/openphoto/default
     openphoto -p -X POST -e /photo/upload.json -F 'photo=@/path/to/photo/jpg' -F 'permission=1'
@@ -109,12 +117,3 @@ You can run commands to the OpenPhoto API from your shell!
             ...
         }
     }    
-
-<a name="credentials"></a>
-#### Getting your credentials
-
-To get your credentials:
- * Log into your Trovebox site
- * Click the arrow on the top-right and select 'Settings'.
- * Click the 'Create a new app' button.
- * Click the 'View' link beside the newly created app.

--- a/openphoto/__init__.py
+++ b/openphoto/__init__.py
@@ -5,14 +5,20 @@ import api_tag
 import api_album
 
 class OpenPhoto(OpenPhotoHttp):
-    """ Client library for OpenPhoto """
-    def __init__(self, host, 
+    """
+    Client library for OpenPhoto
+    If no parameters are specified, config is loaded from the default
+        location (~/.config/openphoto/default).
+    The config_file parameter is used to specify an alternate config file.
+    If the host parameter is specified, no config file is loaded.
+    """
+    def __init__(self, config_file=None, host=None,
                  consumer_key='', consumer_secret='',
                  token='', token_secret=''):
-        OpenPhotoHttp.__init__(self, host, 
+        OpenPhotoHttp.__init__(self, config_file, host,
                                consumer_key, consumer_secret,
                                token, token_secret)
- 
+
         self.photos = api_photo.ApiPhotos(self)
         self.photo = api_photo.ApiPhoto(self)
         self.tags = api_tag.ApiTags(self)

--- a/openphoto/openphoto_http.py
+++ b/openphoto/openphoto_http.py
@@ -245,6 +245,6 @@ class OpenPhotoHttp:
 
         # Trim quotes
         config = parser.items(section)
-        config = [(item[0], item[1].replace('"', '')) for item in config]
-        config = [(item[0], item[1].replace("'", "")) for item in config]
+        config = [(item[0].replace('"', ''), item[1].replace('"', '')) for item in config]
+        config = [(item[0].replace("'", ""), item[1].replace("'", "")) for item in config]
         return dict(config)

--- a/tests/README.markdown
+++ b/tests/README.markdown
@@ -5,22 +5,26 @@ Tests for the Open Photo API / Python Library
 ----------------------------------------
 <a name="requirements"></a>
 ### Requirements
-A computer, Python 2.7 and an empty OpenPhoto instance.
+A computer, Python 2.7 and an empty OpenPhoto test host.
 
 ---------------------------------------
 <a name="setup"></a>
 ### Setting up 
 
-Create a tests/tokens.py file containing the following:
+Create a ``~/.config/openphoto/test`` config file containing the following:
 
-    # tests/tokens.py
-    consumer_key = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-    consumer_secret = "xxxxxxxxxx"
-    token = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-    token_secret = "xxxxxxxxxx"
-    host = "your_hostname"
+    # ~/.config/openphoto/test
+    host = your.host.com
+    consumerKey = your_consumer_key
+    consumerSecret = your_consumer_secret
+    token = your_access_token
+    tokenSecret = your_access_token_secret
 
 Make sure this is an empty test server, **not a production OpenPhoto server!!!**
+
+You can specify an alternate test config file with the following environment variable:
+
+    export OPENPHOTO_TEST_CONFIG=test2
 
 ---------------------------------------
 <a name="running"></a>

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,21 +1,7 @@
+import os
 import unittest
 import logging
 import openphoto
-
-try:
-    import tokens
-except ImportError:
-    print ("********************************************************************\n"
-           "You need to create a 'tokens.py' file containing the following:\n\n"
-           "   host = \"<test_url>\"\n"
-           "   consumer_key = \"<test_consumer_key>\"\n"
-           "   consumer_secret = \"<test_consumer_secret>\"\n"
-           "   token = \"<test_token>\"\n"
-           "   token_secret = \"<test_token_secret>\"\n"
-           "   host = \"<hostname>\"\n\n"
-           "WARNING: Don't use a production OpenPhoto instance for this!\n"
-           "********************************************************************\n")
-    raise
 
 class TestBase(unittest.TestCase):
     TEST_TITLE = "Test Image - delete me!"
@@ -36,24 +22,23 @@ class TestBase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         """ Ensure there is nothing on the server before running any tests """
-        cls.client = openphoto.OpenPhoto(tokens.host,
-                             tokens.consumer_key, tokens.consumer_secret,
-                             tokens.token, tokens.token_secret)
+        config_file = os.getenv("OPENPHOTO_TEST_CONFIG", "test")
+        cls.client = openphoto.OpenPhoto(config_file=config_file)
 
         if cls.client.photos.list() != []:
             raise ValueError("The test server (%s) contains photos. "
                              "Please delete them before running the tests"
-                             % tokens.host)
+                             % cls.client._host)
 
         if cls.client.tags.list() != []:
             raise ValueError("The test server (%s) contains tags. "
                              "Please delete them before running the tests"
-                             % tokens.host)
+                             % cls.client._host)
 
         if cls.client.albums.list() != []:
             raise ValueError("The test server (%s) contains albums. "
                              "Please delete them before running the tests"
-                             % tokens.host)
+                             % cls.client._host)
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -33,6 +33,7 @@ class TestConfig(unittest.TestCase):
         f.write("tokenSecret = '%s_token_secret'\n" % config_file)
 
     def test_default_config(self):
+        """ Ensure the default config is loaded """
         self.create_config("default", "Test Default Host")
         client = openphoto.OpenPhoto()
         self.assertEqual(client._host, "Test Default Host")
@@ -42,6 +43,7 @@ class TestConfig(unittest.TestCase):
         self.assertEqual(client._token_secret, "default_token_secret")
 
     def test_custom_config(self):
+        """ Ensure a custom config can be loaded """
         self.create_config("default", "Test Default Host")
         self.create_config("custom", "Test Custom Host")
         client = openphoto.OpenPhoto(config_file="custom")
@@ -51,7 +53,19 @@ class TestConfig(unittest.TestCase):
         self.assertEqual(client._token, "custom_token")
         self.assertEqual(client._token_secret, "custom_token_secret")
 
+    def test_full_config_path(self):
+        """ Ensure a full custom config path can be loaded """
+        self.create_config("path", "Test Path Host")
+        full_path = os.path.abspath(CONFIG_PATH)
+        client = openphoto.OpenPhoto(config_file=os.path.join(full_path, "path"))
+        self.assertEqual(client._host, "Test Path Host")
+        self.assertEqual(client._consumer_key, "path_consumer_key")
+        self.assertEqual(client._consumer_secret, "path_consumer_secret")
+        self.assertEqual(client._token, "path_token")
+        self.assertEqual(client._token_secret, "path_token_secret")
+
     def test_host_override(self):
+        """ Ensure that specifying a host overrides the default config """
         self.create_config("default", "Test Default Host")
         client = openphoto.OpenPhoto(host="host_override")
         self.assertEqual(client._host, "host_override")
@@ -60,14 +74,16 @@ class TestConfig(unittest.TestCase):
         self.assertEqual(client._token, "")
         self.assertEqual(client._token_secret, "")
 
-    def test_missing_config_files(self):
+    def test_missing_config_files_raise_exceptions(self):
+        """ Ensure that missing config files raise exceptions """
         with self.assertRaises(IOError):
             openphoto.OpenPhoto()
         with self.assertRaises(IOError):
             openphoto.OpenPhoto(config_file="custom")
 
     def test_host_and_config_file_raises_exception(self):
-        self.create_config("custom", "Test Custon Host")
+        """ It's not valid to specify both a host and a config_file """
+        self.create_config("custom", "Test Custom Host")
         with self.assertRaises(ValueError):
             openphoto.OpenPhoto(config_file="custom", host="host_override")
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,74 @@
+import unittest
+import os
+import shutil
+import openphoto
+
+CONFIG_HOME_PATH = os.path.join("test", "config")
+CONFIG_PATH = os.path.join(CONFIG_HOME_PATH, "openphoto")
+
+class TestConfig(unittest.TestCase):
+    def setUp(self):
+        """ Override XDG_CONFIG_HOME env var, to use test configs """
+        try:
+            self.original_xdg_config_home = os.environ["XDG_CONFIG_HOME"]
+        except KeyError:
+            self.original_xdg_config_home = None
+        os.environ["XDG_CONFIG_HOME"] = CONFIG_HOME_PATH
+        os.makedirs(CONFIG_PATH)
+
+    def tearDown(self):
+        if self.original_xdg_config_home is None:
+            del os.environ["XDG_CONFIG_HOME"]
+        else:
+            os.environ["XDG_CONFIG_HOME"] = self.original_xdg_config_home
+        shutil.rmtree(CONFIG_HOME_PATH, ignore_errors=True)
+
+    def create_config(self, config_file, host):
+        f = open(os.path.join(CONFIG_PATH, config_file), "w")
+        f.write("host = %s\n" % host)
+        f.write("# Comment\n\n")
+        f.write("consumerKey = \"%s_consumer_key\"\n" % config_file)
+        f.write("\"consumerSecret\" = %s_consumer_secret\n" % config_file)
+        f.write("'token'=%s_token\n" % config_file)
+        f.write("tokenSecret = '%s_token_secret'\n" % config_file)
+
+    def test_default_config(self):
+        self.create_config("default", "Test Default Host")
+        client = openphoto.OpenPhoto()
+        self.assertEqual(client._host, "Test Default Host")
+        self.assertEqual(client._consumer_key, "default_consumer_key")
+        self.assertEqual(client._consumer_secret, "default_consumer_secret")
+        self.assertEqual(client._token, "default_token")
+        self.assertEqual(client._token_secret, "default_token_secret")
+
+    def test_custom_config(self):
+        self.create_config("default", "Test Default Host")
+        self.create_config("custom", "Test Custom Host")
+        client = openphoto.OpenPhoto(config_file="custom")
+        self.assertEqual(client._host, "Test Custom Host")
+        self.assertEqual(client._consumer_key, "custom_consumer_key")
+        self.assertEqual(client._consumer_secret, "custom_consumer_secret")
+        self.assertEqual(client._token, "custom_token")
+        self.assertEqual(client._token_secret, "custom_token_secret")
+
+    def test_host_override(self):
+        self.create_config("default", "Test Default Host")
+        client = openphoto.OpenPhoto(host="host_override")
+        self.assertEqual(client._host, "host_override")
+        self.assertEqual(client._consumer_key, "")
+        self.assertEqual(client._consumer_secret, "")
+        self.assertEqual(client._token, "")
+        self.assertEqual(client._token_secret, "")
+
+    def test_missing_config_files(self):
+        with self.assertRaises(IOError):
+            openphoto.OpenPhoto()
+        with self.assertRaises(IOError):
+            openphoto.OpenPhoto(config_file="custom")
+
+    def test_host_and_config_file_raises_exception(self):
+        self.create_config("custom", "Test Custon Host")
+        with self.assertRaises(ValueError):
+            openphoto.OpenPhoto(config_file="custom", host="host_override")
+
+


### PR DESCRIPTION
Config files are not just useful from the command line, They're also a handy way of specifying the host's OAuth credentials within the Python environment.

This PR refactors the config parser into the OpenPhoto class. This extends the current method of creating an OpenPhoto client:

```
client = OpenPhoto(host, consumer_key, consumer_secret, token, token_secret)
```

If the host isn't specified, it loads the default config file:

```
client = OpenPhoto()
```

Alternate config files can also be used:

```
client = OpenPhoto(config_file="config_name")
client = OpenPhoto(config_file="/path/to/config_file")
```

Other updates:
- The README files have been updated to make this clear.
- The commandline tool now explains how to create credentials (closes #10).
- Add config file unit tests.
- Use config files to specify test servers ("test" by default, can be overridden using the OPENPHOTO_TEST_CONFIG environment variable).
