### PR TITLE
Allow -h to be used to specify the hostname

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -79,9 +79,9 @@ You can run commands to the OpenPhoto API from your shell!
 
 These are the options you can pass to the shell program:
 
-    -h             # Display help text
+    --help         # Display help text
     -c config_file # Either the name of a config file in ~/.config/openphoto/ or a full path to a config file
-    -H hostname    # Overrides config_file for unauthenticated API calls
+    -h hostname    # Overrides config_file for unauthenticated API calls
     -e endpoint    # [default=/photos/list.json]
     -X method      # [default=GET]
     -F params      # e.g. -F 'title=my title' -F 'tags=mytag1,mytag2'
@@ -105,7 +105,7 @@ These are the options you can pass to the shell program:
     }
     
     # Get a thumbnail URL from current.openphoto.me (unauthenticated access)
-    openphoto -H current.openphoto.me -p -e /photo/62/view.json -F 'returnSizes=20x20'
+    openphoto -h current.openphoto.me -p -e /photo/62/view.json -F 'returnSizes=20x20'
     {
         "code":200,
         "message":"Photo 62",

--- a/openphoto/main.py
+++ b/openphoto/main.py
@@ -15,10 +15,11 @@ from openphoto import OpenPhoto
 #################################################################
 
 def main(args=sys.argv[1:]):
-    parser = OptionParser()
+    usage = "%prog --help"
+    parser = OptionParser(usage, add_help_option=False)
     parser.add_option('-c', '--config', action='store', type='string', dest='config_file',
                       help="Configuration file to use")
-    parser.add_option('-H', '--host', action='store', type='string', dest='host',
+    parser.add_option('-h', '-H', '--host', action='store', type='string', dest='host',
                       help="Hostname of the OpenPhoto server (overrides config_file)")
     parser.add_option('-X', action='store', type='choice', dest='method', choices=('GET', 'POST'),
                       help="Method to use (GET or POST)", default="GET")
@@ -31,8 +32,16 @@ def main(args=sys.argv[1:]):
                       help="Pretty print the json")
     parser.add_option('-v', action="store_true", dest="verbose", default=False,
                       help="Verbose output")
+    parser.add_option('--help', action="store_true", help='show this help message')
 
     options, args = parser.parse_args(args)
+
+    if options.help:
+        parser.print_help()
+        return
+
+    if args:
+        parser.error("Unknown argument: %s" % args)
 
     params = {}
     if options.fields:


### PR DESCRIPTION
This matches the behaviour of the other commandline tools.
Since this is a bit non-standard, the usage message now specifically mentions the --help option.
Also added a check for excess arguments.
