### PR TITLE
Apiv1 fixes

### DIFF
--- a/openphoto/objects.py
+++ b/openphoto/objects.py
@@ -114,6 +114,11 @@ class Photo(OpenPhotoObject):
         """
         new_dict = self._openphoto.post("/photo/%s/transform.json" % self.id,
                                         **kwds)["result"]
+
+        # APIv1 doesn't return the transformed photo (frontend issue #955)
+        if isinstance(new_dict, bool):
+            new_dict = self._openphoto.get("/photo/%s/view.json" % self.id)["result"]
+
         self._replace_fields(new_dict)
 
 class Tag(OpenPhotoObject):
@@ -173,6 +178,11 @@ class Album(OpenPhotoObject):
         """ Update this album with the specified parameters """
         new_dict = self._openphoto.post("/album/%s/update.json" % self.id, 
                                         **kwds)["result"]
+
+        # APIv1 doesn't return the updated album (frontend issue #937)
+        if isinstance(new_dict, bool):
+            new_dict = self._openphoto.get("/album/%s/view.json" % self.id)["result"]
+
         self._replace_fields(new_dict)
         self._update_fields_with_objects()
         

--- a/tests/README.markdown
+++ b/tests/README.markdown
@@ -61,3 +61,15 @@ Ensure there are:
 **TearDownClass:**
 
 Remove all photos, tags and albums
+
+### Testing old servers
+
+By default, all currently supported API versions will be tested.
+It's useful to test servers that only support older API versions.
+To restrict the testing to a specific maximum API version, use the
+``OPENPHOTO_TEST_SERVER_API`` environment variable.
+
+For example, to restrict testing to APIv1 and APIv2:
+
+    export OPENPHOTO_TEST_SERVER_API=2
+

--- a/tests/api_versions/test_v1.py
+++ b/tests/api_versions/test_v1.py
@@ -7,6 +7,5 @@ class TestAlbumsV1(test_albums.TestAlbums):
 class TestPhotosV1(test_photos.TestPhotos):
     api_version = 1
 
-# The tag API didn't work at v1 - see frontend issue #927
-# class TestTagsV1(test_tags.TestTags):
-    # api_version = 1
+class TestTagsV1(test_tags.TestTags):
+    api_version = 1

--- a/tests/api_versions/test_v1.py
+++ b/tests/api_versions/test_v1.py
@@ -1,3 +1,4 @@
+import unittest
 from tests import test_albums, test_photos, test_tags
 
 class TestAlbumsV1(test_albums.TestAlbums):
@@ -6,5 +7,6 @@ class TestAlbumsV1(test_albums.TestAlbums):
 class TestPhotosV1(test_photos.TestPhotos):
     api_version = 1
 
-class TestTagsV1(test_tags.TestTags):
-    api_version = 1
+# The tag API didn't work at v1 - see frontend issue #927
+# class TestTagsV1(test_tags.TestTags):
+    # api_version = 1

--- a/tests/api_versions/test_v2.py
+++ b/tests/api_versions/test_v2.py
@@ -1,10 +1,14 @@
-from tests import test_albums, test_photos, test_tags
+import unittest
+from tests import test_base, test_albums, test_photos, test_tags
 
+@unittest.skipIf(test_base.get_test_server_api() < 2, "Don't test future API versions")
 class TestAlbumsV2(test_albums.TestAlbums):
     api_version = 2
 
+@unittest.skipIf(test_base.get_test_server_api() < 2, "Don't test future API versions")
 class TestPhotosV2(test_photos.TestPhotos):
     api_version = 2
 
+@unittest.skipIf(test_base.get_test_server_api() < 2, "Don't test future API versions")
 class TestTagsV2(test_tags.TestTags):
     api_version = 2

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,4 +1,5 @@
 import unittest
+import os
 import logging
 import openphoto
 
@@ -15,6 +16,9 @@ except ImportError:
            "WARNING: Don't use a production OpenPhoto instance for this!\n"
            "********************************************************************\n")
     raise
+
+def get_test_server_api():
+    return int(os.getenv("OPENPHOTO_TEST_SERVER_API", openphoto.LATEST_API_VERSION))
 
 class TestBase(unittest.TestCase):
     TEST_TITLE = "Test Image - delete me!"

--- a/tests/test_framework.py
+++ b/tests/test_framework.py
@@ -27,7 +27,7 @@ class TestFramework(test_base.TestBase):
 
     def test_specified_api_version(self):
         # For all API versions >0, we get a generic hello world message
-        for api_version in range(1, openphoto.LATEST_API_VERSION + 1):
+        for api_version in range(1, test_base.get_test_server_api() + 1):
             client = self.create_client_from_base(api_version=api_version)
             result = client.get("hello.json")
             self.assertEqual(result['message'], "Hello, world!")

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -8,7 +8,11 @@ class TestTags(test_base.TestBase):
     testcase_name = "tag API"
 
     def test_create_delete(self, tag_id="create_tag"):
-        """ Create a tag then delete it """
+        """
+        Create a tag then delete it.
+        This test is a little contrived, since the tag create/delete
+        endpoints are only intended for internal use.
+        """
         # Create a tag
         self.assertTrue(self.client.tag.create(tag_id))
         # Check that the tag doesn't exist (It has no photos, so it's invisible)
@@ -23,13 +27,21 @@ class TestTags(test_base.TestBase):
         self.assertTrue(self.client.tag.delete(tag_id))
         # Check that the tag is now gone
         self.assertNotIn(tag_id, [t.id for t in self.client.tags.list()])
+        # Also remove the tag from the photo
+        self.photos[0].update(tagsRemove=tag_id)
 
-        # Create then delete using the Tag object directly
+        # Create the tag again
         self.photos[0].update(tagsAdd=tag_id)
+        self.assertIn(tag_id, [t.id for t in self.client.tags.list()])
+
+        # Delete using the tag object directly
         tag = [t for t in self.client.tags.list() if t.id == tag_id][0]
         self.assertTrue(tag.delete())
+
         # Check that the tag is now gone
         self.assertNotIn(tag_id, [t.id for t in self.client.tags.list()])
+        # Also remove the tag from the photo
+        self.photos[0].update(tagsRemove=tag_id)
 
     # TODO: Un-skip and update this tests once there are tag fields that can be updated.
     # The owner field cannot be updated.

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -2,6 +2,8 @@ import unittest
 import openphoto
 import test_base
 
+@unittest.skipIf(test_base.get_test_server_api() == 1,
+                 "The tag API didn't work at v1 - see frontend issue #927")
 class TestTags(test_base.TestBase):
     testcase_name = "tag API"
 


### PR DESCRIPTION
Workarounds to support APIv1 properly.

Add OPENPHOTO_TEST_SERVER_API env var, to allow testing to be restricted to a specific maximum API version. This allows new API testcases to be skipped for old servers.

Explicitly remove tags from photos during tag testing. The tag create/delete API endpoints seem to be for internal use only, so these tests are a little contrived.
