### PR TITLE
Test improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 *.egg-info
 tests/tokens.py
 tests.log
+.tox

--- a/run_tests
+++ b/run_tests
@@ -1,0 +1,25 @@
+#!/bin/bash
+#
+# Simple script to run all tests with multiple test servers.
+#
+
+unset OPENPHOTO_TEST_DEBUG
+
+# Default test server running latest self-hosted site
+echo "Testing latest self-hosted site"
+export OPENPHOTO_TEST_CONFIG=test
+unset OPENPHOTO_TEST_SERVER_API
+python -m unittest discover -c
+
+# Test server running APIv1 OpenPhoto instance
+echo "Testing APIv1 self-hosted site"
+export OPENPHOTO_TEST_CONFIG=test-apiv1
+export OPENPHOTO_TEST_SERVER_API=1
+python -m unittest discover -c
+
+# Test account on hosted trovebox.com site
+echo "Testing latest hosted site"
+export OPENPHOTO_TEST_CONFIG=test-hosted
+unset OPENPHOTO_TEST_SERVER_API
+python -m unittest discover -c
+

--- a/run_tests
+++ b/run_tests
@@ -1,25 +1,34 @@
 #!/bin/bash
 #
-# Simple script to run all tests with multiple test servers.
+# Simple script to run all tests with multiple test servers
+# across all supported Python versions
 #
 
-unset OPENPHOTO_TEST_DEBUG
-
 # Default test server running latest self-hosted site
-echo "Testing latest self-hosted site"
+
+tput setaf 3
+echo
+echo "Testing latest self-hosted site..."
+tput sgr0
 export OPENPHOTO_TEST_CONFIG=test
 unset OPENPHOTO_TEST_SERVER_API
-python -m unittest discover -c
+tox $@
 
 # Test server running APIv1 OpenPhoto instance
-echo "Testing APIv1 self-hosted site"
+tput setaf 3
+echo
+echo "Testing APIv1 self-hosted site..."
+tput sgr0
 export OPENPHOTO_TEST_CONFIG=test-apiv1
 export OPENPHOTO_TEST_SERVER_API=1
-python -m unittest discover -c
+tox $@
 
 # Test account on hosted trovebox.com site
-echo "Testing latest hosted site"
+tput setaf 3
+echo
+echo "Testing latest hosted site..."
+tput sgr0
 export OPENPHOTO_TEST_CONFIG=test-hosted
 unset OPENPHOTO_TEST_SERVER_API
-python -m unittest discover -c
+tox $@
 

--- a/tests/README.markdown
+++ b/tests/README.markdown
@@ -42,6 +42,10 @@ The easiest way to run a subset of the tests is with nose:
 
 All HTTP requests and responses are recorded in the file "tests.log".
 
+You can enable more verbose output to stdout with the following environment variable:
+
+    export OPENPHOTO_TEST_DEBUG=1
+
 ---------------------------------------
 <a name="test_details"></a>
 ### Test Details

--- a/tests/README.markdown
+++ b/tests/README.markdown
@@ -81,3 +81,19 @@ For example, to restrict testing to APIv1 and APIv2:
 
     export OPENPHOTO_TEST_SERVER_API=2
 
+
+<a name="full_regression"></a>
+### Full Regression Test
+
+If you want to run a full regression test across all supported API revisions,
+you must set up multiple OpenPhoto instances and create the following config
+files containing your credentials:
+
+    test        : Latest self-hosted site
+    test-apiv1  : APIv1 self-hosted site
+    test-hosted : Credentials for test account on trovebox.com
+
+Once these are set up, the following command tests them all in one go:
+
+    ./run_tests
+

--- a/tests/README.markdown
+++ b/tests/README.markdown
@@ -5,7 +5,7 @@ Tests for the Open Photo API / Python Library
 ----------------------------------------
 <a name="requirements"></a>
 ### Requirements
-A computer, Python 2.7 and an empty OpenPhoto test host.
+A computer, Python and an empty OpenPhoto test host.
 
 ---------------------------------------
 <a name="setup"></a>
@@ -30,17 +30,20 @@ You can specify an alternate test config file with the following environment var
 <a name="running"></a>
 ### Running the tests
 
+The following instructions are for Python 2.7. You can adapt them for earlier
+Python versions using the ``unittest2`` package.
+
     cd /path/to/openphoto-python
     python -m unittest discover -c
 
 The "-c" lets you stop the tests gracefully with \[CTRL\]-c.
 
-The easiest way to run a subset of the tests is with nose:
+The easiest way to run a subset of the tests is with the ``nose`` package:
 
     cd /path/to/openphoto-python
     nosetests -v -s --nologcapture tests/test_albums.py:TestAlbums.test_view
 
-All HTTP requests and responses are recorded in the file "tests.log".
+All HTTP requests and responses are recorded in the file ``tests.log``.
 
 You can enable more verbose output to stdout with the following environment variable:
 
@@ -50,7 +53,9 @@ You can enable more verbose output to stdout with the following environment vari
 <a name="test_details"></a>
 ### Test Details
 
-These tests are intended to verify the Python library. They don't provide comprehensive testing of the OpenPhoto API, there are PHP unit tests for that.
+These tests are intended to verify the openphoto-python library.
+They don't provide comprehensive testing of the OpenPhoto API,
+there are PHP unit tests for that.
 
 Each test class is run as follows:
 
@@ -81,19 +86,16 @@ For example, to restrict testing to APIv1 and APIv2:
 
     export OPENPHOTO_TEST_SERVER_API=2
 
-
 <a name="full_regression"></a>
 ### Full Regression Test
 
-If you want to run a full regression test across all supported API revisions,
-you must set up multiple OpenPhoto instances and create the following config
-files containing your credentials:
+The ``run_tests`` script uses the ``tox`` package to run a full regression across:
+ * Multiple Python versions
+ * All supported API versions
+
+To use it, you must set up multiple OpenPhoto instances and create the following
+config files containing your credentials:
 
     test        : Latest self-hosted site
     test-apiv1  : APIv1 self-hosted site
     test-hosted : Credentials for test account on trovebox.com
-
-Once these are set up, the following command tests them all in one go:
-
-    ./run_tests
-

--- a/tests/api_versions/test_v1.py
+++ b/tests/api_versions/test_v1.py
@@ -1,4 +1,7 @@
-import unittest
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 from tests import test_albums, test_photos, test_tags
 
 class TestAlbumsV1(test_albums.TestAlbums):

--- a/tests/api_versions/test_v2.py
+++ b/tests/api_versions/test_v2.py
@@ -1,4 +1,7 @@
-import unittest
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 from tests import test_base, test_albums, test_photos, test_tags
 
 @unittest.skipIf(test_base.get_test_server_api() < 2, "Don't test future API versions")

--- a/tests/test_albums.py
+++ b/tests/test_albums.py
@@ -1,4 +1,7 @@
-import unittest
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 import openphoto
 import test_base
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,6 +1,9 @@
 import sys
 import os
-import unittest
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 import logging
 import openphoto
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,3 +1,4 @@
+import sys
 import os
 import unittest
 import logging
@@ -13,7 +14,9 @@ class TestBase(unittest.TestCase):
     MAXIMUM_TEST_PHOTOS = 4 # Never have more the 4 photos on the test server
     testcase_name = "(unknown testcase)"
     api_version = None
+
     config_file = os.getenv("OPENPHOTO_TEST_CONFIG", "test")
+    debug = (os.getenv("OPENPHOTO_TEST_DEBUG", "0") == "1")
 
     def __init__(self, *args, **kwds):
         unittest.TestCase.__init__(self, *args, **kwds)
@@ -27,10 +30,11 @@ class TestBase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         """ Ensure there is nothing on the server before running any tests """
-        if cls.api_version is None:
-            print "\nTesting Latest %s" % cls.testcase_name
-        else:
-            print "\nTesting %s v%d" % (cls.testcase_name, cls.api_version)
+        if cls.debug:
+            if cls.api_version is None:
+                print "\nTesting Latest %s" % cls.testcase_name
+            else:
+                print "\nTesting %s v%d" % (cls.testcase_name, cls.api_version)
 
         cls.client = openphoto.OpenPhoto(config_file=cls.config_file,
                                          api_version=cls.api_version)
@@ -63,8 +67,11 @@ class TestBase(unittest.TestCase):
         """
         self.photos = self.client.photos.list()
         if len(self.photos) != 3:
-#            print self.photos
-            print "[Regenerating Photos]"
+            if self.debug:
+                print "[Regenerating Photos]"
+            else:
+                print " ",
+                sys.stdout.flush()
             if len(self.photos) > 0:
                 self._delete_all()
             self._create_test_photos()
@@ -74,7 +81,11 @@ class TestBase(unittest.TestCase):
         if (len(self.tags) != 1 or
                 self.tags[0].id != self.TEST_TAG or
                 str(self.tags[0].count) != "3"):
-            print "[Regenerating Tags]"
+            if self.debug:
+                print "[Regenerating Tags]"
+            else:
+                print " ",
+                sys.stdout.flush()
             self._delete_all()
             self._create_test_photos()
             self.photos = self.client.photos.list()
@@ -87,7 +98,11 @@ class TestBase(unittest.TestCase):
         if (len(self.albums) != 1 or
                 self.albums[0].name != self.TEST_ALBUM or
                 self.albums[0].count != "3"):
-            print "[Regenerating Albums]"
+            if self.debug:
+                print "[Regenerating Albums]"
+            else:
+                print " ",
+                sys.stdout.flush()
             self._delete_all()
             self._create_test_photos()
             self.photos = self.client.photos.list()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,7 +6,7 @@ import os
 import shutil
 import openphoto
 
-CONFIG_HOME_PATH = os.path.join("test", "config")
+CONFIG_HOME_PATH = os.path.join("tests", "config")
 CONFIG_PATH = os.path.join(CONFIG_HOME_PATH, "openphoto")
 
 class TestConfig(unittest.TestCase):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,7 @@
-import unittest
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 import os
 import shutil
 import openphoto

--- a/tests/test_framework.py
+++ b/tests/test_framework.py
@@ -1,4 +1,7 @@
-import unittest
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 import logging
 import openphoto
 import test_base

--- a/tests/test_photos.py
+++ b/tests/test_photos.py
@@ -1,4 +1,7 @@
-import unittest
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 import openphoto
 import test_base
 

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -1,4 +1,7 @@
-import unittest
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 import openphoto
 import test_base
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,8 @@
+[tox]
+envlist = py27
+
+[testenv]
+commands = unit2 discover --catch
+deps =
+    unittest2
+    discover

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27
+envlist = py27,py26
 
 [testenv]
 commands = unit2 discover --catch


### PR DESCRIPTION
Add `tox` support, for running tests across multiple Python versions.
Reduce default verbosity.
Add run_tests script to test all API versions across all Python versions.
Test support for Python 2.6
