### PR TITLE
Don't set/replace/delete TroveboxObject attributes that start with an underscore

### DIFF
--- a/trovebox/objects.py
+++ b/trovebox/objects.py
@@ -20,9 +20,8 @@ class TroveboxObject(object):
     def _set_fields(self, json_dict):
         """ Set this object's attributes specified in json_dict """
         for key, value in json_dict.items():
-            if key.startswith("_"):
-                raise ValueError("Illegal attribute: %s" % key)
-            setattr(self, key, value)
+            if not key.startswith("_"):
+                setattr(self, key, value)
 
     def _replace_fields(self, json_dict):
         """
@@ -30,7 +29,8 @@ class TroveboxObject(object):
         those in json_dict.
         """
         for key in self._json_dict.keys():
-            delattr(self, key)
+            if not key.startswith("_"):
+                delattr(self, key)
         self._json_dict = json_dict
         self._set_fields(json_dict)
 
@@ -39,7 +39,8 @@ class TroveboxObject(object):
         Delete this object's attributes, including name and id
         """
         for key in self._json_dict.keys():
-            delattr(self, key)
+            if not key.startswith("_"):
+                delattr(self, key)
         self._json_dict = {}
         self.id = None
         self.name = None


### PR DESCRIPTION
Just ignore them, don't raise an exception
