### PR TITLE
Skip the photo.delete_source test

### DIFF
--- a/tests/functional/test_photos.py
+++ b/tests/functional/test_photos.py
@@ -75,6 +75,7 @@ class TestPhotos(test_base.TestBase):
         self._delete_all()
         self._create_test_photos()
 
+    @unittest.skip("This test doesn't work if the server is behind a cache")
     def test_delete_source(self):
         """ Test that photo source files can be deleted """
         # Upload a new (duplicate) public photo


### PR DESCRIPTION
Skip the photo.delete_source test, since it doesn't work if the photos are cached
