### PR TITLE
Perform user expansion when uploading files from the CLI.

### DIFF
--- a/trovebox/main.py
+++ b/trovebox/main.py
@@ -122,9 +122,8 @@ def extract_files(params):
     files = {}
     updated_params = {}
     for name in params:
-        if (name == "photo" and params[name].startswith("@") and
-                os.path.isfile(os.path.expanduser(params[name][1:]))):
-            files[name] = open(params[name][1:], 'rb')
+        if name == "photo" and params[name].startswith("@"):
+            files[name] = open(os.path.expanduser(params[name][1:]), 'rb')
         else:
             updated_params[name] = params[name]
 


### PR DESCRIPTION
Don't ignore missing files - allow an exception to be raised.
Add extra CLI file upload unit tests.

Fixes #59.
