### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ Trovebox Python Library
    :alt: Coverage Status
    :target: https://coveralls.io/r/photo/openphoto-python?branch=master
 
-.. image:: https://pypip.in/v/trovebox/badge.png
+.. image:: https://img.shields.io/pypi/v/trovebox.svg
    :alt: Python Package Index (PyPI)
    :target: https://pypi.python.org/pypi/trovebox
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20trovebox))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `trovebox`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.